### PR TITLE
Highlight all the assert_* and refute_* methods

### DIFF
--- a/after/syntax/ruby.vim
+++ b/after/syntax/ruby.vim
@@ -1,3 +1,6 @@
+syntax match rubyTestAssertionOrRefutation "\vassert_(\w|\?|!)+"
+syntax match rubyTestAssertionOrRefutation "\vrefute_(\w|\?|!)+"
+
 syntax keyword rubyTestMethod
       \ assert
       \ assert_block
@@ -78,4 +81,5 @@ syntax keyword rubyTestStatement
       \ teardown
 
 highlight link rubyTestMethod Function
+highlight link rubyTestAssertionOrRefutation Function
 highlight link rubyTestStatement Statement


### PR DESCRIPTION
Since it's common to write custom assertion or refutations, I like to have also my own methods highlighted as default minitest methods. This way, I can easily see where the assertions and refutations are.

It's mostly a matter of taste, your choice :smile: 
