### PR TITLE
Syntax folding on `describe` and `it` blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+doc/tags

--- a/after/syntax/ruby.vim
+++ b/after/syntax/ruby.vim
@@ -70,15 +70,15 @@ syntax keyword rubyTestStatement
       \ after
       \ before
       \ context
-      \ describe
       \ expect
-      \ it
       \ setup
       \ should
       \ teardown
       \ scenario
       \ feature
       \ background
+
+" See after/syntax/ruby/minitest.vim for "describe, it" blocks definition
 
 highlight link rubyTestMethod Function
 highlight link rubyTestStatement Statement

--- a/after/syntax/ruby/minitest.vim
+++ b/after/syntax/ruby/minitest.vim
@@ -1,0 +1,20 @@
+let s:fold = get(b:, 'ruby_minitest_fold', get(g:, 'ruby_minitest_fold'))
+let s:i = ''
+
+if !has('folding') || empty(s:fold)
+  let s:fold = ''
+else
+  let s:fold = ' fold'
+endif
+
+" Regions for `describe ... end` blocks,
+" named with `rubyMinitestDescribeBlock` and so on.
+for s:i in ['describe', 'it']
+  let s:group_name = 'rubyMinitest' . substitute(s:i, '^.', '\u\0', '') . 'Block'
+  execute 'syntax region ' . s:group_name . ' matchgroup=rubyControl ' .
+        \ 'start="^\z(\s*\)' . s:i . '\>[?!]\@!" ' .
+        \ 'end="^\z1end\>" ' .
+        \ 'contains=ALLBUT,@rubyNotTop' .
+        \ s:fold
+endfor
+unlet s:i

--- a/doc/ft-ruby-minitest-syntax.txt
+++ b/doc/ft-ruby-minitest-syntax.txt
@@ -7,7 +7,10 @@ OPTIONS ~
 ruby_minitest_fold  (default: none) ~
 
   Set to 1 to enable |folding| on main section blocks (`describe` and `it`
-  blocks). >
+  blocks).
+
+  Note: to reduce complexity, only `end` with same indentation level as
+  its beginning is detected. >
 
     let g:ruby_minitest_fold = 1
 <

--- a/doc/ft-ruby-minitest-syntax.txt
+++ b/doc/ft-ruby-minitest-syntax.txt
@@ -1,0 +1,20 @@
+RUBY MINITEST             *ruby-minitest-syntax.vim*  *ft-rubyminitest-syntax*
+
+==============================================================================
+OPTIONS ~
+
+                                                          *ruby_minitest_fold*
+ruby_minitest_fold  (default: none) ~
+
+  Set to 1 to enable |folding| on main section blocks (`describe` and `it`
+  blocks). >
+
+    let g:ruby_minitest_fold = 1
+<
+  - Must set before loading this syntax file. e.g., in .vimrc.
+  - Remember also set 'foldmethod' to "syntax".
+  - Support global (|g:|) or buffer-local (|b:|) setting.
+
+
+==============================================================================
+vim:tw=78:fo=tcroq2mM:et:sts=2:sw=2:ft=help:norl:


### PR DESCRIPTION
Hi, how about adding fold feature to `describe` and `it` blocks?

Since these sections provide good outline for test file, it would be useful to allow syntax fold on them.

I've read [tpope/vim-rails](https://github.com/tpope/vim-rails) and [bruno-/vim-ruby-fold](https://github.com/bruno-/vim-ruby-fold) but still feel implement it here is more suitable.