### PR TITLE
Skip folding region definition if disabled

### DIFF
--- a/after/syntax/ruby/minitest.vim
+++ b/after/syntax/ruby/minitest.vim
@@ -2,7 +2,10 @@ let s:fold = get(b:, 'ruby_minitest_fold', get(g:, 'ruby_minitest_fold'))
 let s:i = ''
 
 if !has('folding') || empty(s:fold)
-  let s:fold = ''
+  syntax keyword rubyTestMethod
+        \ describe
+        \ it
+  finish
 else
   let s:fold = ' fold'
 endif

--- a/doc/ft-ruby-minitest-syntax.txt
+++ b/doc/ft-ruby-minitest-syntax.txt
@@ -10,7 +10,7 @@ ruby_minitest_fold  (default: none) ~
   blocks).
 
   Note: to reduce complexity, only `end` with same indentation level as
-  its beginning is detected. >
+        its beginning is detected. >
 
     let g:ruby_minitest_fold = 1
 <
@@ -18,6 +18,9 @@ ruby_minitest_fold  (default: none) ~
   - Remember also set 'foldmethod' to "syntax".
   - Support global (|g:|) or buffer-local (|b:|) setting.
 
+  Note: Enabling ruby_mintest_fold if using another Ruby plug-in that provides
+  folding, especially vim-ruby, is discouraged; block folding regions are
+  defined in these plug-ins in incompatible ways.
 
 ==============================================================================
 vim:tw=78:fo=tcroq2mM:et:sts=2:sw=2:ft=help:norl:


### PR DESCRIPTION
Fixes #10; vim-ruby and vim-ruby-minitest define block regions in
incompatible ways. Therefore, if you do not have ruby_minitest_fold
enabled, this plug-in behaves the same way it did previously.
